### PR TITLE
Fix: sidebar navigation arrow

### DIFF
--- a/features/layout/sidebar-navigation/menu-item-button.tsx
+++ b/features/layout/sidebar-navigation/menu-item-button.tsx
@@ -22,7 +22,13 @@ export function MenuItemButton({
     <li className={classNames(styles.listItem, className)}>
       <Button className={styles.anchor} onClick={onClick}>
         {/* eslint-disable-next-line @next/next/no-img-element */}
-        <img className={styles.icon} src={iconSrc} alt={`${text} icon`} />{" "}
+        <img
+          className={
+            isCollapsed && text === "Collapse" ? styles.righticon : styles.icon
+          }
+          src={iconSrc}
+          alt={`${text} icon`}
+        />{" "}
         {!isCollapsed && text}{" "}
       </Button>
     </li>

--- a/features/layout/sidebar-navigation/menu-item-link.module.scss
+++ b/features/layout/sidebar-navigation/menu-item-link.module.scss
@@ -30,3 +30,9 @@
   width: space.$s6;
   margin-right: space.$s3;
 }
+
+.righticon {
+  width: space.$s6;
+  margin-right: space.$s3;
+  transform: rotate(180deg);
+}


### PR DESCRIPTION
How I solved the challenge; 

className={isCollapsed && text === "Collapse" ? styles.righticon : styles.icon}`

If the sidebar is collapsed (isCollapsed is true) and the text is "Collapse", it applies styles.righticon.
Otherwise, it applies the default styles.icon.

I then copied and pasted the original css for the icon and added;

transform: rotate(180deg);