### PR TITLE
Fix: separator line inside card is too thick

### DIFF
--- a/features/projects/components/project-card/project-card.module.scss
+++ b/features/projects/components/project-card/project-card.module.scss
@@ -19,7 +19,8 @@
 
 .bottomContainer {
   padding: space.$s4 space.$s6;
-  border-top: 3px solid color.$gray-200;
+  border-top: 1px solid color.$gray-200;
+  align-self: stretch;
   display: flex;
   justify-content: flex-end;
 }


### PR DESCRIPTION
Fixed thickness of card, by setting the thickness of the border to 1px as per design.