### PR TITLE
Fix navigation support button

### DIFF
--- a/cypress/e2e/navigation.cy.ts
+++ b/cypress/e2e/navigation.cy.ts
@@ -36,7 +36,8 @@ describe("Sidebar Navigation", () => {
       cy.get("nav").contains("Collapse").click();
 
       // check that links still exist and are functionable
-      cy.get("nav").find("a").should("have.length", 5).eq(1).click();
+      cy.get("nav").find("a").should("have.length", 6).eq(1).click();
+      cy.url().should("eq", "http://localhost:3000/dashboard/issues");
       cy.url().should("eq", "http://localhost:3000/dashboard/issues");
 
       // check that text is not rendered
@@ -80,7 +81,7 @@ describe("Sidebar Navigation", () => {
       isInViewport("nav");
 
       // check that all links are rendered
-      cy.get("nav").find("a").should("have.length", 5);
+      cy.get("nav").find("a").should("have.length", 6);
 
       // Support button should be rendered but Collapse button not
       cy.get("nav").contains("Support").should("exist");

--- a/cypress/e2e/navigation.cy.ts
+++ b/cypress/e2e/navigation.cy.ts
@@ -14,9 +14,9 @@ describe("Sidebar Navigation", () => {
         .contains("Projects")
         .should("have.attr", "href", "/dashboard");
 
-      cy.get("nav")
-        .contains("Issues")
-        .should("have.attr", "href", "/dashboard/issues");
+      cy.get("nav").contains("Issues").click();
+      cy.url().should("eq", "http://localhost:3000/dashboard/issues");
+      cy.get("h1").contains("Issues");
 
       cy.get("nav")
         .contains("Alerts")
@@ -29,6 +29,14 @@ describe("Sidebar Navigation", () => {
       cy.get("nav")
         .contains("Settings")
         .should("have.attr", "href", "/dashboard/settings");
+
+      cy.get("nav")
+        .contains("Support")
+        .should(
+          "have.attr",
+          "href",
+          "mailto:support@prolog-app.com?subject=Support Request: ",
+        );
     });
 
     it("is collapsible", () => {

--- a/features/layout/sidebar-navigation/sidebar-navigation.tsx
+++ b/features/layout/sidebar-navigation/sidebar-navigation.tsx
@@ -79,11 +79,12 @@ export function SidebarNavigation() {
             ))}
           </ul>
           <ul className={styles.list}>
-            <MenuItemButton
+            <MenuItemLink
               text="Support"
               iconSrc="/icons/support.svg"
               isCollapsed={isSidebarCollapsed}
-              onClick={() => alert("Support")}
+              href="mailto:support@prolog-app.com?subject=Support Request: "
+              isActive={false}
             />
             <MenuItemButton
               text="Collapse"


### PR DESCRIPTION
cy.get() is a Cypress command used to select and get a DOM element. In this case, it's selecting a nav element.

In summary, these lines of code are checking that within the nav element, there is an element containing the text "Support," and that this element has an href attribute equal to a specific mailto link, indicating that clicking the "Support" link should trigger an email to "[support@prolog-app.com](mailto:support@prolog-app.com)" with the subject "Support Request."