### PR TITLE
Fix issue list number of events and users

### DIFF
--- a/api/issues.types.ts
+++ b/api/issues.types.ts
@@ -12,4 +12,5 @@ export type Issue = {
   stack: string;
   level: IssueLevel;
   numEvents: number;
+  numUsers: number;
 };

--- a/cypress/e2e/issue-list.cy.ts
+++ b/cypress/e2e/issue-list.cy.ts
@@ -81,7 +81,7 @@ describe("Issue List", () => {
       cy.reload();
       cy.wait(["@getProjects", "@getIssuesPage2"]);
       cy.wait(1500);
-      cy.contains("Page 1 of 3");
+      cy.contains("Page 2 of 3");
     });
   });
 });

--- a/cypress/e2e/issue-list.cy.ts
+++ b/cypress/e2e/issue-list.cy.ts
@@ -45,6 +45,7 @@ describe("Issue List", () => {
           cy.wrap($el).contains(issue.name);
           cy.wrap($el).contains(issue.message);
           cy.wrap($el).contains(issue.numEvents);
+          cy.wrap($el).contains(issue.numUsers);
           cy.wrap($el).contains(firstLineOfStackTrace);
         });
     });
@@ -80,7 +81,7 @@ describe("Issue List", () => {
       cy.reload();
       cy.wait(["@getProjects", "@getIssuesPage2"]);
       cy.wait(1500);
-      cy.contains("Page 2 of 3");
+      cy.contains("Page 1 of 3");
     });
   });
 });

--- a/features/issues/components/issue-list/issue-row.tsx
+++ b/features/issues/components/issue-list/issue-row.tsx
@@ -17,7 +17,7 @@ const levelColors = {
 };
 
 export function IssueRow({ projectLanguage, issue }: IssueRowProps) {
-  const { name, message, stack, level, numEvents } = issue;
+  const { name, message, stack, level, numEvents, numUsers } = issue;
   const firstLineOfStackTrace = stack.split("\n")[1];
 
   return (
@@ -43,7 +43,7 @@ export function IssueRow({ projectLanguage, issue }: IssueRowProps) {
         </Badge>
       </td>
       <td className={styles.cell}>{numEvents}</td>
-      <td className={styles.cell}>{numEvents}</td>
+      <td className={styles.cell}>{numUsers}</td>
     </tr>
   );
 }


### PR DESCRIPTION
In summary, this cypress test checks that each issue in the list is correctly rendered in the HTML table, with its name, message, number of events, number of users, and the first line of its stack trace. If any of these elements are not found as expected, the test will fail.