### PR TITLE
UI kit checkbox

### DIFF
--- a/features/ui/checkbox/checkbox.module.scss
+++ b/features/ui/checkbox/checkbox.module.scss
@@ -1,0 +1,3 @@
+@use "@styles/color";
+@use "@styles/space";
+@use "@styles/font";

--- a/features/ui/checkbox/checkbox.module.scss
+++ b/features/ui/checkbox/checkbox.module.scss
@@ -1,3 +1,131 @@
 @use "@styles/color";
 @use "@styles/space";
 @use "@styles/font";
+
+.checkbox {
+  // apply default styles
+  position: relative;
+  color: color.$gray-700;
+
+  // custom checkbox
+  span {
+    box-sizing: border-box;
+    position: absolute;
+    top: 0;
+    left: 0;
+    background-color: #fff;
+    border: 1px solid color.$gray-300;
+    border-radius: 6px;
+  }
+
+  // checkbox size
+  &.sm {
+    font: font.$text-sm-medium;
+    padding-left: space.$s4;
+
+    span {
+      width: space.$s4;
+      height: space.$s4;
+    }
+  }
+
+  &.md {
+    font: font.$text-md-medium;
+    padding-left: space.$s8;
+    padding-top: 0.1rem;
+
+    span {
+      width: space.$s5;
+      height: space.$s5;
+    }
+  }
+
+  &:hover input ~ span {
+    background-color: color.$primary-50;
+    border-color: color.$primary-600;
+  }
+
+  &:focus-within input ~ span {
+    box-shadow: 0 0 0 3px color.$primary-100;
+    border-color: color.$primary-300;
+  }
+
+  input {
+    position: absolute;
+    opacity: 0;
+    cursor: pointer;
+    height: 0;
+    width: 0;
+  }
+
+  // input checked
+  &.sm.check input:checked ~ span {
+    border-color: color.$primary-600;
+    background:
+      url("../../../public/icons/check-sm.svg") no-repeat center,
+      color.$primary-50;
+  }
+
+  &.md.check input:checked ~ span {
+    border-color: color.$primary-600;
+    background:
+      url("../../../public/icons/check-md.svg") no-repeat center,
+      color.$primary-50;
+  }
+
+  &.sm.partly input:checked ~ span {
+    border-color: color.$primary-600;
+    background:
+      url("../../../public/icons/partly-check-sm.svg") no-repeat center,
+      color.$primary-50;
+  }
+
+  &.md.partly input:checked ~ span {
+    border-color: color.$primary-600;
+    background:
+      url("../../../public/icons/partly-check-md.svg") no-repeat center,
+      color.$primary-50;
+  }
+
+  // input disabled
+  &:has(input:disabled) {
+    color: color.$gray-300;
+
+    &.md.check span,
+    &.sm.check span,
+    &.md.partly span,
+    &.sm.partly span {
+      background-color: color.$gray-100;
+      border-color: color.$gray-200;
+      box-shadow: none;
+    }
+
+    &.md.check input:checked ~ span {
+      border-color: color.$gray-200;
+      background:
+        url("../../../public/icons/check-grey-md.svg") no-repeat center,
+        color.$gray-100;
+    }
+
+    &.sm.check input:checked ~ span {
+      border-color: color.$gray-200;
+      background:
+        url("../../../public/icons/check-grey-sm.svg") no-repeat center,
+        color.$gray-100;
+    }
+
+    &.md.partly input:checked ~ span {
+      border-color: color.$gray-200;
+      background:
+        url("../../../public/icons/partly-grey-md.svg") no-repeat center,
+        color.$gray-100;
+    }
+
+    &.sm.partly input:checked ~ span {
+      border-color: color.$gray-200;
+      background:
+        url("../../../public/icons/partly-grey-sm.svg") no-repeat center,
+        color.$gray-100;
+    }
+  }
+}

--- a/features/ui/checkbox/checkbox.stories.tsx
+++ b/features/ui/checkbox/checkbox.stories.tsx
@@ -1,0 +1,39 @@
+import React from "react";
+import { Meta, StoryFn } from "@storybook/react";
+import { Checkbox, CheckboxSize } from "./checkbox";
+
+export default {
+  title: "UI/Checkbox",
+  component: Checkbox,
+  parameters: {
+    // More on Story layout: https://storybook.js.org/docs/react/configure/story-layout
+    layout: "fullscreen",
+  },
+} as Meta<typeof Checkbox>;
+
+const Template: StoryFn<typeof Checkbox> = ({
+  size,
+  label,
+  checkboxType,
+  disabled,
+  checked,
+}) => (
+  <div style={{ padding: 10 }}>
+    <Checkbox
+      size={size}
+      label={label}
+      checkboxType={checkboxType}
+      disabled={disabled}
+      checked={checked}
+    ></Checkbox>
+  </div>
+);
+
+export const Default = Template.bind({});
+Default.args = {
+  size: CheckboxSize.sm,
+  label: "",
+};
+Default.parameters = {
+  viewMode: "docs",
+};

--- a/features/ui/checkbox/checkbox.tsx
+++ b/features/ui/checkbox/checkbox.tsx
@@ -1,0 +1,48 @@
+import React, { HTMLAttributes } from "react";
+import classNames from "classnames";
+import styles from "./checkbox.module.scss";
+
+export enum CheckboxSize {
+  sm = "sm",
+  md = "md",
+}
+
+export enum CheckboxType {
+  unechecked = "unchecked",
+  check = "check",
+  partly = "partly",
+}
+
+interface CheckboxProps {
+  size?: CheckboxSize;
+  label?: string;
+  checkboxType?: CheckboxType;
+}
+
+interface CheckBoxAttributes extends HTMLAttributes<HTMLInputElement> {
+  disabled?: boolean;
+  checked?: boolean;
+}
+
+export function Checkbox({
+  size = CheckboxSize.sm,
+  label = "",
+  checkboxType = CheckboxType.check,
+  ...CheckboxProps
+}: CheckBoxAttributes & CheckboxProps) {
+  return (
+    <label
+      data-disabled={CheckboxProps.disabled}
+      className={classNames(
+        styles[size],
+        styles.checkbox,
+        styles[checkboxType],
+      )}
+    >
+      {label ? `${label}` : null}
+      <input type="checkbox" {...CheckboxProps} />
+
+      <span></span>
+    </label>
+  );
+}

--- a/features/ui/checkbox/checkbox.tsx
+++ b/features/ui/checkbox/checkbox.tsx
@@ -19,6 +19,7 @@ interface CheckboxProps {
   checkboxType?: CheckboxType;
 }
 
+// Additional HTML attributes for the checkbox input
 interface CheckBoxAttributes extends HTMLAttributes<HTMLInputElement> {
   disabled?: boolean;
   checked?: boolean;
@@ -46,3 +47,5 @@ export function Checkbox({
     </label>
   );
 }
+/* Empty span element; creating a custom-styled checkbox.
+The span doesn't contain any actual content but is used purely for its visual styling properties to represent the appearance of a checkbox in different states and sizes */

--- a/features/ui/checkbox/index.ts
+++ b/features/ui/checkbox/index.ts
@@ -1,0 +1,1 @@
+export { Checkbox, CheckboxSize, CheckboxType } from "./checkbox";

--- a/public/icons/check-grey-md.svg
+++ b/public/icons/check-grey-md.svg
@@ -1,0 +1,3 @@
+<svg width="14" height="14" viewBox="0 0 14 14" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M11.6666 3.5L5.24992 9.91667L2.33325 7" stroke="#E4E7EC" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/public/icons/check-grey-sm.svg
+++ b/public/icons/check-grey-sm.svg
@@ -1,0 +1,3 @@
+<svg width="12" height="12" viewBox="0 0 12 12" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M10 3L4.5 8.5L2 6" stroke="#E4E7EC" stroke-width="1.6666" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/public/icons/check-md.svg
+++ b/public/icons/check-md.svg
@@ -1,0 +1,3 @@
+<svg width="14" height="14" viewBox="0 0 14 14" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M11.6666 3.5L5.24992 9.91667L2.33325 7" stroke="#7F56D9" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/public/icons/check-sm.svg
+++ b/public/icons/check-sm.svg
@@ -1,0 +1,3 @@
+<svg width="12" height="12" viewBox="0 0 12 12" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M10 3L4.5 8.5L2 6" stroke="#7F56D9" stroke-width="1.6666" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/public/icons/partly-check-md.svg
+++ b/public/icons/partly-check-md.svg
@@ -1,0 +1,3 @@
+<svg width="14" height="14" viewBox="0 0 14 14" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M2.91675 7H11.0834" stroke="#7F56D9" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/public/icons/partly-check-sm.svg
+++ b/public/icons/partly-check-sm.svg
@@ -1,0 +1,3 @@
+<svg width="12" height="12" viewBox="0 0 12 12" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M2.5 6H9.5" stroke="#7F56D9" stroke-width="1.66666" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/public/icons/partly-grey-md.svg
+++ b/public/icons/partly-grey-md.svg
@@ -1,0 +1,3 @@
+<svg width="14" height="14" viewBox="0 0 14 14" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M2.91675 7H11.0834" stroke="#E4E7EC" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/public/icons/partly-grey-sm.svg
+++ b/public/icons/partly-grey-sm.svg
@@ -1,0 +1,3 @@
+<svg width="12" height="12" viewBox="0 0 12 12" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M2.5 6H9.5" stroke="#E4E7EC" stroke-width="1.66666" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>


### PR DESCRIPTION
Summary ; 
- In the CSS, input:checked is a selector targeting a checkbox input in its checked state.
- The .check class is used in CSS to differentiate styles for the checked state of checkboxes based on their size (small or medium)
- he general sibling combinator (~) is used to select a sibling element (e.g., <span>) based on the state of the checkbox
- The class "check" is used in the CheckboxType enum to define checkbox types and set the default type for the Checkbox component